### PR TITLE
Fix argument check

### DIFF
--- a/Paket.CredentialProvider.Gen2Support/Program.fs
+++ b/Paket.CredentialProvider.Gen2Support/Program.fs
@@ -52,8 +52,8 @@ let impl argv =
 
     let hasFlag (flag : string) =
         argv |> Seq.exists (fun s -> s.Equals(flag, StringComparison.InvariantCultureIgnoreCase))
-    let nonInteractive = hasFlag "nonInteractive"
-    let isRetry = hasFlag "isRetry"
+    let nonInteractive = hasFlag "-nonInteractive"
+    let isRetry = hasFlag "-isRetry"
 
     let plugins =
         SecurePluginCredentialProviderBuilder(pluginManager = PluginManager.Instance, canShowDialog = true, logger = NullLogger.Instance)


### PR DESCRIPTION
While the check for the URI correctly checks for a hypen the hasFlag function does not. There might be a better fix but for now its enough to add the hyphen in the compared string.

This will fix endless loops when a token has expired, since the Microsoft provider only updates the token if isRetry is set to true.